### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository. It is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Klevu_MysqlCompat
 This is a compatible sub package to the [klevu-smart-search-M2](https://github.com/klevu/klevu-smart-search-M2) repository. 
 
-Only useful when website is using the Catalog Search Engine as MySQL and [Preserve Your Theme Layout](https://support.klevu.com/knowledgebase/preserving-your-theme-layout-for-the-search-results-page-magento-2/) for Search Result Page.
+Only useful when website is using the Catalog Search Engine as MySQL and [Preserve Your Theme Layout](https://help.klevu.com/support/solutions/articles/5000871515-preserving-theme-layout) for Search Result Page.
 
 This module created to make the Klevu Magento 2 module compatible with MySQL catalog search engine.
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "magento/framework": "@stable"
     },
     "type": "magento-module",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
…to enable Mysql search backend with Klevu Search. This is a mandatory
package for Magento 2.0x-2.3x.

Please, see klevu-smart-search-M2/README.md for more information on how
to install the overall extension.