### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository. It is …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klevu/module-mysqlcompat",
     "description": "Klevu Search MySQL compatibility module from Magento 2.0 to Magento 2.3.x versions",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0",
         "magento/module-store": "@stable",
         "magento/module-catalog": "@stable",
         "magento/module-backend": "@stable",
@@ -10,7 +10,7 @@
         "magento/framework": "@stable"
     },
     "type": "magento-module",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
…to enable Mysql search backend with Klevu Search.

This is a mandatory package for Magento 2.0x-2.3x.
Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.